### PR TITLE
Update author annotation to give partial authorship for code blocks

### DIFF
--- a/src/main/java/reposense/authorship/FileInfoAnalyzer.java
+++ b/src/main/java/reposense/authorship/FileInfoAnalyzer.java
@@ -15,6 +15,7 @@ import reposense.authorship.analyzer.AnnotatorAnalyzer;
 import reposense.authorship.model.FileInfo;
 import reposense.authorship.model.FileResult;
 import reposense.authorship.model.LineInfo;
+import reposense.authorship.model.TextBlockInfo;
 import reposense.git.GitBlame;
 import reposense.git.GitLog;
 import reposense.model.Author;
@@ -100,8 +101,14 @@ public class FileInfoAnalyzer {
             Author author = line.getAuthor();
             authorContributionMap.put(author, authorContributionMap.getOrDefault(author, 0) + 1);
         }
+
+        for (TextBlockInfo block : fileInfo.getTextBlocks()) {
+            block.getAbsoluteContributionMap().forEach((author, integer)
+                    -> authorContributionMap
+                        .put(author, authorContributionMap.getOrDefault(author, 0) + integer));
+        }
         return FileResult.createTextFileResult(
-            fileInfo.getPath(), fileInfo.getFileType(), fileInfo.getLines(), authorContributionMap);
+            fileInfo.getPath(), fileInfo.getFileType(), fileInfo.getLines(), fileInfo.getTextBlocks(), authorContributionMap);
     }
 
     /**

--- a/src/main/java/reposense/authorship/FileResultAggregator.java
+++ b/src/main/java/reposense/authorship/FileResultAggregator.java
@@ -5,6 +5,7 @@ import java.util.List;
 import reposense.authorship.model.AuthorshipSummary;
 import reposense.authorship.model.FileResult;
 import reposense.authorship.model.LineInfo;
+import reposense.authorship.model.TextBlockInfo;
 import reposense.model.Author;
 import reposense.model.FileType;
 
@@ -20,16 +21,8 @@ public class FileResultAggregator {
             List<FileType> fileTypes) {
         AuthorshipSummary authorContributionSummary = new AuthorshipSummary(fileResults, authors, fileTypes);
         for (FileResult fileResult : fileResults) {
-            if (fileResult.isBinary()) {
-                continue;
-            }
-            for (LineInfo lineInfo : fileResult.getLines()) {
-                Author author = lineInfo.getAuthor();
-                if (!authors.contains(author)) {
-                    continue;
-                }
-                authorContributionSummary.addAuthorContributionCount(author, fileResult.getFileType());
-            }
+                authorContributionSummary
+                    .addAuthorContributionCount(fileResult.getAuthorContributionMap(), fileResult.getFileType());
         }
         return authorContributionSummary;
     }

--- a/src/main/java/reposense/authorship/analyzer/AnnotatorAnalyzer.java
+++ b/src/main/java/reposense/authorship/analyzer/AnnotatorAnalyzer.java
@@ -25,7 +25,7 @@ import reposense.model.AuthorConfiguration;
 public class AnnotatorAnalyzer {
     private static final String AUTHOR_TAG = "@@author";
     // GitHub username format
-    private static final String REGEX_AUTHOR_NAME_FORMAT = "@[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}\\s\\d+";
+    private static final String REGEX_AUTHOR_NAME_FORMAT = "@[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}\\s\\d*";
     private static final Pattern PATTERN_AUTHOR_NAME_FORMAT = Pattern.compile(REGEX_AUTHOR_NAME_FORMAT);
     private static final String REGEX_AUTHOR_TAG_FORMAT = "@@author(\\s+[^\\s]+)?";
 
@@ -96,12 +96,9 @@ public class AnnotatorAnalyzer {
     }
 
     /**
-     * Extracts the author name from the given {@code line}, finds the corresponding {@code Author}
-     * in {@code authorAliasMap}, and returns this {@code Author} stored in an {@code Optional}.
-     * @return {@code Optional.of(Author#UNKNOWN_AUTHOR)} if there is an author config file and
-     *              no matching {@code Author} is found,
-     *         {@code Optional.empty()} if an end author tag is used (i.e. "@@author"),
-     *         {@code Optional.of(Author#tagged author)} otherwise.
+     * Extracts the author name and correspond authorship weight from the given {@code line},
+     * finds the corresponding {@code Author} in {@code authorAliasMap}, and returns the author
+     * and their authorship weight as a key-value pair in a hashmap stored in an {@code Optional}.
      */
     private static Optional<HashMap<Author, Integer>> findAuthorsInLine(String line, AuthorConfiguration authorConfig,
         boolean foundStartAnnotation, int formatIndex, Path filePath) {
@@ -126,7 +123,7 @@ public class AnnotatorAnalyzer {
                     String parameters = matcher.group();
                     String[] splitParameters = parameters.split(" ");
                     String author = splitParameters[0].split("@")[1];
-                    Integer weight = Integer.parseInt(splitParameters[1]);
+                    Integer weight = Integer.parseInt(splitParameters[1].isEmpty() ? "100" : splitParameters[1]);
 
                     if (!authorAliasMap.containsKey(author) && !AuthorConfiguration.hasAuthorConfigFile()) {
                         authorConfig.addAuthor(new Author(author));

--- a/src/main/java/reposense/authorship/model/AuthorshipSummary.java
+++ b/src/main/java/reposense/authorship/model/AuthorshipSummary.java
@@ -35,6 +35,16 @@ public class AuthorshipSummary {
         fileTypeContributionMap.put(fileType, fileTypeContributionMap.getOrDefault(fileType, 0) + 1);
     }
 
+    /**
+     * Increments the corresponding {@code fileType} contribution count of {@code author} by one.
+     */
+    public void addAuthorContributionCount(HashMap<Author, Integer> authorContributionMap, FileType fileType) {
+        authorContributionMap.forEach((author, integer) -> {
+            Map<FileType, Integer> fileTypeContributionMap = authorFileTypeContributionMap.get(author);
+            fileTypeContributionMap.put(fileType, fileTypeContributionMap.getOrDefault(fileType, 0) + integer);
+        });
+    }
+
     public Map<Author, LinkedHashMap<FileType, Integer>> getAuthorFileTypeContributionMap() {
         return authorFileTypeContributionMap;
     }

--- a/src/main/java/reposense/authorship/model/FileInfo.java
+++ b/src/main/java/reposense/authorship/model/FileInfo.java
@@ -14,6 +14,7 @@ import reposense.util.SystemUtil;
 public class FileInfo {
     private final String path;
     private final ArrayList<LineInfo> lines;
+    private final ArrayList<TextBlockInfo> blocks = new ArrayList<>();
 
     private FileType fileType;
 
@@ -42,12 +43,28 @@ public class FileInfo {
         lines.add(line);
     }
 
+    public void removeLine(LineInfo line) {
+        lines.remove(line);
+    }
+
+    public void addTextBlock(TextBlockInfo block) {
+        blocks.add(block);
+    }
+
+    public void removeTextBlock(TextBlockInfo block) {
+        blocks.remove(block);
+    }
+
     public int getNumOfLines() {
         return lines.size();
     }
 
     public ArrayList<LineInfo> getLines() {
         return lines;
+    }
+
+    public ArrayList<TextBlockInfo> getTextBlocks() {
+        return blocks;
     }
 
     public String getPath() {

--- a/src/main/java/reposense/authorship/model/FileInfo.java
+++ b/src/main/java/reposense/authorship/model/FileInfo.java
@@ -114,4 +114,12 @@ public class FileInfo {
         return path.equals(otherFileInfo.path)
                 && lines.equals(otherFileInfo.lines);
     }
+
+    public boolean removeLines(ArrayList<LineInfo> toRemove) {
+        return lines.removeAll(toRemove);
+    }
+
+    public boolean addBlocks(ArrayList<TextBlockInfo> toAdd) {
+        return blocks.addAll(toAdd);
+    }
 }

--- a/src/main/java/reposense/authorship/model/FileResult.java
+++ b/src/main/java/reposense/authorship/model/FileResult.java
@@ -15,13 +15,15 @@ public class FileResult {
     private FileType fileType;
     private Boolean isBinary = null; // Should only be true or null to prevent it from being serialized
     private final ArrayList<LineInfo> lines;
+    private final ArrayList<TextBlockInfo> blocks;
     private final HashMap<Author, Integer> authorContributionMap;
 
-    public FileResult(String path, FileType fileType, ArrayList<LineInfo> lines,
+    public FileResult(String path, FileType fileType, ArrayList<LineInfo> lines, ArrayList<TextBlockInfo> blocks,
             HashMap<Author, Integer> authorContributionMap, boolean isBinary) {
         this.path = path;
         this.fileType = fileType;
         this.lines = lines;
+        this.blocks = blocks;
         this.authorContributionMap = authorContributionMap;
         if (isBinary) {
             this.isBinary = true;
@@ -29,13 +31,13 @@ public class FileResult {
     }
 
     public static FileResult createTextFileResult(String path, FileType fileType, ArrayList<LineInfo> lines,
-            HashMap<Author, Integer> authorContributionMap) {
-        return new FileResult(path, fileType, lines, authorContributionMap, false);
+                                                  ArrayList<TextBlockInfo> textBlocks, HashMap<Author, Integer> authorContributionMap) {
+        return new FileResult(path, fileType, lines, textBlocks, authorContributionMap, false);
     }
 
     public static FileResult createBinaryFileResult(String path, FileType fileType, HashMap<Author,
             Integer> authorContributionMap) {
-        return new FileResult(path, fileType, new ArrayList<>(), authorContributionMap, true);
+        return new FileResult(path, fileType, new ArrayList<>(), null, authorContributionMap, true);
     }
 
     public boolean isBinary() {
@@ -44,6 +46,10 @@ public class FileResult {
 
     public List<LineInfo> getLines() {
         return lines;
+    }
+
+    public List<TextBlockInfo> getBlocks() {
+        return blocks;
     }
 
     public String getPath() {

--- a/src/main/java/reposense/authorship/model/TextBlockInfo.java
+++ b/src/main/java/reposense/authorship/model/TextBlockInfo.java
@@ -1,0 +1,119 @@
+package reposense.authorship.model;
+
+import reposense.model.Author;
+
+import java.util.*;
+
+public class TextBlockInfo {
+    private int startLineNumber;
+    private int endLineNumber;
+    private HashMap<Author, Integer> contributionMap;
+    private HashMap<Author, Integer> absoluteContributionMap = null;
+    private ArrayList<LineInfo> lines;
+    private Date lastModifiedDate;
+
+    private transient boolean isTracked;
+
+    public TextBlockInfo(int startLineNumber, int endLineNumber, ArrayList<LineInfo> lines) {
+        this.startLineNumber = startLineNumber;
+        this.endLineNumber = endLineNumber;
+        this.lines = lines;
+
+        isTracked = true;
+    }
+
+    public TextBlockInfo() {
+        this.lines = new ArrayList<>();
+        this.contributionMap = new HashMap<>();
+
+        isTracked = true;
+    }
+
+    public HashMap<Author, Integer> getContributionMap() {
+        return contributionMap;
+    }
+
+    public HashMap<Author, Integer> getAbsoluteContributionMap() {
+        if (this.absoluteContributionMap == null) {
+            int sum = 0;
+            Iterator<Map.Entry<Author, Integer>> iterator = contributionMap.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<Author, Integer> element = iterator.next();
+                sum += element.getValue();
+            }
+
+            int totalLines = endLineNumber - startLineNumber;
+            int finalSum = sum;
+            contributionMap.forEach((author, integer) ->
+                contributionMap.put(author, (integer * totalLines) / finalSum));
+        }
+        return this.absoluteContributionMap;
+
+    }
+
+    public void setContributionMap(HashMap<Author, Integer> contributionMap) {
+        this.contributionMap = contributionMap;
+    }
+
+    public int getStartLineNumber() {
+        return startLineNumber;
+    }
+
+    public void setStartLineNumber(int startLineNumber) {
+        this.startLineNumber = startLineNumber;
+    }
+
+    public int getEndLineNumber() {
+        return endLineNumber;
+    }
+
+    public void setEndLineNumber(int endLineNumber) {
+        this.endLineNumber = endLineNumber;
+    }
+
+    public void setTracked(boolean isTracked) {
+        this.isTracked = isTracked;
+    }
+
+    public Date getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+
+    public void setLastModifiedDate(Date lastModifiedDate) {
+        this.lastModifiedDate = lastModifiedDate;
+    }
+
+    public boolean isTracked() {
+        return isTracked;
+    }
+
+    public void addLine(LineInfo line) {
+        this.lines.add(line);
+    }
+
+    public void removeLine(LineInfo line) {
+        this.lines.remove(line);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof TextBlockInfo)) {
+            return false;
+        }
+
+        TextBlockInfo otherTextBlockInfo = (TextBlockInfo) other;
+        return startLineNumber == otherTextBlockInfo.startLineNumber
+                && endLineNumber == otherTextBlockInfo.endLineNumber
+                && contributionMap.equals(otherTextBlockInfo.contributionMap)
+                && absoluteContributionMap.equals(otherTextBlockInfo.absoluteContributionMap)
+                && lines.equals(otherTextBlockInfo.lines)
+                && isTracked == otherTextBlockInfo.isTracked
+                && ((lastModifiedDate == null && otherTextBlockInfo.lastModifiedDate == null)
+                || (lastModifiedDate.equals(otherTextBlockInfo.lastModifiedDate)));
+    }
+
+}

--- a/src/main/java/reposense/authorship/model/TextBlockInfo.java
+++ b/src/main/java/reposense/authorship/model/TextBlockInfo.java
@@ -36,6 +36,7 @@ public class TextBlockInfo {
     public HashMap<Author, Integer> getAbsoluteContributionMap() {
         if (this.absoluteContributionMap == null) {
             int sum = 0;
+            HashMap<Author, Integer> map = new HashMap<>();
             Iterator<Map.Entry<Author, Integer>> iterator = contributionMap.entrySet().iterator();
             while (iterator.hasNext()) {
                 Map.Entry<Author, Integer> element = iterator.next();
@@ -45,7 +46,8 @@ public class TextBlockInfo {
             int totalLines = endLineNumber - startLineNumber;
             int finalSum = sum;
             contributionMap.forEach((author, integer) ->
-                contributionMap.put(author, (integer * totalLines) / finalSum));
+                    map.put(author, (integer * totalLines) / finalSum));
+            this.absoluteContributionMap = map;
         }
         return this.absoluteContributionMap;
 
@@ -69,6 +71,10 @@ public class TextBlockInfo {
 
     public void setEndLineNumber(int endLineNumber) {
         this.endLineNumber = endLineNumber;
+    }
+
+    public int numOfLines() {
+        return lines.size();
     }
 
     public void setTracked(boolean isTracked) {


### PR DESCRIPTION
A particular code block might have input from more than 1 person.
For example, another person might have resolved conflicts that arose
from a merge. Current assignment is all or nothing for any particular
line.

Let's extend the author notation to credit multiple contributors
with fields to enter a percentage representation of contribution.

Example of an annotation:
"@@author hpkoh 30 xyz 70" of a particular code block give
@hpkoh authorship of 30% of the total lines and @xyz authorship of
70 percent of the total lines.

`TextBlockInfo class` encapsulates blocks of codes that are group together
typically because the accurate attribution of that particular block deviates 
from the git blame information and is manually annotated.
Lines belonging to this class is removed from `FileInfo.lines` so they are not iterated through doubly
like before.

`TextBlockInfo.contributionMap` stores the contribution weight of every author given in the author tag
In the above example
"hpkoh" will have the value "30" and "xyz" will have the value "70"

 `TextBlockInfo.absoluteContributionMap` maps each author with the implicit number of lines attributed 
to them for the authorship report. It is derived simply by multiplying the total number of lines by the by
the relatively weight of authorship for each author.
For example, if the above example is for a code block of 50 lines, `hpkoh` will be attributed with 50 x 30/100
= 15 lines and `xyz` will be attributed with 35 lines.

Below are screenshots showing the results.
The following file.txt file has a 16 line block which is annotated with " hpkoh 30 xyz 70"
![image](https://user-images.githubusercontent.com/53825802/147251379-3ed7da39-f431-4e40-b0ac-0067df4ddf06.png)

As a result, 11(16 x 0.7) lines of that particular block is attributed to xyz as seen below.
However, the front line has not been updated to support showing partial authorship of a block
![image](https://user-images.githubusercontent.com/53825802/147251331-0f68fb8e-c6fd-4a0d-8157-c1d7292f0e7d.png)

